### PR TITLE
Updating typings to include reflect-metadata

### DIFF
--- a/lib/annotations/Inject.ts
+++ b/lib/annotations/Inject.ts
@@ -1,5 +1,3 @@
-/// <reference path="../../node_modules/reflect-metadata/reflect-metadata.d.ts" />
-
 import 'reflect-metadata';
 import InjectionRequest = require('../InjectionRequest');
 import PrototypeInjectionRequest = require('../PrototypeInjectionRequest');

--- a/typings.json
+++ b/typings.json
@@ -8,6 +8,7 @@
     "express": "github:DefinitelyTyped/DefinitelyTyped/express/express.d.ts#a213223e1bdf40b280ebf765b42e7ef3da9394dc",
     "serve-static": "github:DefinitelyTyped/DefinitelyTyped/serve-static/serve-static.d.ts#a213223e1bdf40b280ebf765b42e7ef3da9394dc",
     "mime": "github:DefinitelyTyped/DefinitelyTyped/mime/mime.d.ts#a213223e1bdf40b280ebf765b42e7ef3da9394dc",
-    "node": "github:DefinitelyTyped/DefinitelyTyped/node/node.d.ts#a213223e1bdf40b280ebf765b42e7ef3da9394dc"
+    "node": "github:DefinitelyTyped/DefinitelyTyped/node/node.d.ts#a213223e1bdf40b280ebf765b42e7ef3da9394dc",
+    "reflect-metadata":"github:rbuckton/ReflectDecorators/reflect-metadata.d.ts"
   }
 }


### PR DESCRIPTION
Removed the reference path from Inject.ts and adding the reflect-metadata typing to the typings json. This will enable Inject js to work with all possible node module structures.
